### PR TITLE
Fix the location of the private key to /etc/auto-ssh-tunnel

### DIFF
--- a/Client/connect.py
+++ b/Client/connect.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 
 # Set-up the config file:
-location_of_pem_file = "/home/install/Downloads/auto-ssh-tunnel/server"
+location_of_pem_file = "/etc/auto-ssh-tunnel/priv_key"
 port_open = "50000"
 username_ipaddress = "server@192.168.1.202"
 

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,10 @@ if platform.system() == "Linux":
 	    subprocess.Popen("cd && mkdir .ssh", shell=True).wait()
 	    subprocess.Popen("yes | cp Client/connect.py /etc/init.d/", shell=True).wait()
             subprocess.Popen("chmod +x /etc/init.d/connect.py", shell=True).wait()
-            subprocess.call("printf 'server\n\n' | ssh-keygen -t rsa -b 2048 -v", shell=True)
+            subprocess.call("printf 'priv_key\n\n' | ssh-keygen -t rsa -b 2048 -v", shell=True)
 
 	    print("[*] Copying SSH-Keys file over to server...")
-	    subprocess.call(['ssh-copy-id', '-i', 'server.pub', rootname])
+	    subprocess.call(['ssh-copy-id', '-i', 'priv_key.pub', rootname])
 
             print("[*] Installing private keys inside protected folder...")
             subprocess.Popen("yes | cp Client/connect.py /usr/local/bin/", shell=True).wait()
@@ -75,8 +75,8 @@ if platform.system() == "Linux":
 	    print("[*] Moving autossh client into the /usr/local/bin/ directory...")
             
 	    print("[*] Moving private key to /etc/auto-ssh-tunnel/")
-            subprocess.Popen("/etc/auto-ssh-tunnel", shell=True).wait()
-            subprocess.Popen("yes | cp server /etc/aut-ssh-tunnel/priv_key", shell=True).wait()
+            subprocess.Popen("mkdir /etc/auto-ssh-tunnel", shell=True).wait()
+            subprocess.Popen("yes | cp priv_key /etc/auto-ssh-tunnel/priv_key", shell=True).wait()
 	except subprocess.CalledProcessError as e:
 	    pass
 	

--- a/setup.py
+++ b/setup.py
@@ -58,17 +58,25 @@ if platform.system() == "Linux":
 	try:
 	    rootname = raw_input("What is the server's rootname@ipaddress?: ")
 	    print("[*] Installing autossh client...")
+
 	    print("[*] Installing autossh as startup application...")
 	    subprocess.Popen("cd && mkdir .ssh", shell=True).wait()
 	    subprocess.Popen("yes | cp Client/connect.py /etc/init.d/", shell=True).wait()
             subprocess.Popen("chmod +x /etc/init.d/connect.py", shell=True).wait()
             subprocess.call("printf 'server\n\n' | ssh-keygen -t rsa -b 2048 -v", shell=True)
+
 	    print("[*] Copying SSH-Keys file over to server...")
 	    subprocess.call(['ssh-copy-id', '-i', 'server.pub', rootname])
+
             print("[*] Installing private keys inside protected folder...")
             subprocess.Popen("yes | cp Client/connect.py /usr/local/bin/", shell=True).wait()
 	    subprocess.Popen("chmod +x /usr/local/bin/connect.py", shell=True).wait()
+
 	    print("[*] Moving autossh client into the /usr/local/bin/ directory...")
+            
+	    print("[*] Moving private key to /etc/auto-ssh-tunnel/")
+            subprocess.Popen("/etc/auto-ssh-tunnel", shell=True).wait()
+            subprocess.Popen("yes | cp server /etc/aut-ssh-tunnel/priv_key", shell=True).wait()
 	except subprocess.CalledProcessError as e:
 	    pass
 	


### PR DESCRIPTION
This removes the need to specify the location of the private key in connect.py.
