### PR TITLE
Replace setup.py prompt for rootname and ip address and remove prompt for passphrase

### DIFF
--- a/Client/connect.py
+++ b/Client/connect.py
@@ -6,7 +6,7 @@ import subprocess
 location_of_pem_file = "/etc/auto-ssh-tunnel/priv_key"
 # configure.py will automatically edit port_open and username_ipaddress
 port_open = "50000"
-username_ipaddress = "server@192.168.0.4"
+username_ipaddress = ""
 
 # A function that checks if there is an existing ssh process running in the backgroun:
 def ssh_running():

--- a/Client/connect.py
+++ b/Client/connect.py
@@ -28,4 +28,6 @@ def run_ssh():
         print "Failed. Please check your config file."
 
 #Main Command
-ssh_running()
+
+if __name__ == "__main__":
+    ssh_running()

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ import sys
 import os
 import platform
 
+from Client import connect
+
 # if nix then run installer
 if platform.system() == "Linux":
     # give installer a null value
@@ -56,7 +58,7 @@ if platform.system() == "Linux":
 	
 	# if installation is done on client, the autossh automatically kicks in the daemon
 	try:
-	    rootname = raw_input("What is the server's rootname@ipaddress?: ")
+	    rootname = connect.username_ipaddress
 	    print("[*] Installing autossh client...")
 
 	    print("[*] Installing autossh as startup application...")

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ if platform.system() == "Linux":
 	# if installation is done on client, the autossh automatically kicks in the daemon
 	try:
 	    rootname = connect.username_ipaddress
+            if rootname == "":
+                print "Please run configure.py first."
+                sys.exit()
+                
 	    print("[*] Installing autossh client...")
 
 	    print("[*] Installing autossh as startup application...")

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ if platform.system() == "Linux":
 	    subprocess.Popen("cd && mkdir .ssh", shell=True).wait()
 	    subprocess.Popen("yes | cp Client/connect.py /etc/init.d/", shell=True).wait()
             subprocess.Popen("chmod +x /etc/init.d/connect.py", shell=True).wait()
-            subprocess.call("printf 'priv_key\n\n' | ssh-keygen -t rsa -b 2048 -v", shell=True)
+            subprocess.call("printf 'priv_key\n\n' | ssh-keygen -t rsa -b 2048 -v -P ''", shell=True)
 
 	    print("[*] Copying SSH-Keys file over to server...")
 	    subprocess.call(['ssh-copy-id', '-i', 'priv_key.pub', rootname])

--- a/test.py
+++ b/test.py
@@ -1,0 +1,2 @@
+from Client import connect
+print connect.username_ipaddress


### PR DESCRIPTION
No longer prompts for "What is the server's rootname@ipaddress?". The info is taken from connect.py. setup.py will prompt the user to run configure.py before setup.py if they have not already done so.

Also removes the double prompt for a passphrase. ssh-keygen will take a blank string "" as the passphrase.
